### PR TITLE
Add `wit-integer-add`

### DIFF
--- a/wit-integer-add/Cargo.toml
+++ b/wit-integer-add/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["host", "lib"]

--- a/wit-integer-add/README.md
+++ b/wit-integer-add/README.md
@@ -1,0 +1,16 @@
+## Description
+
+In this example, we use `wit-bindgen` to generate a wasm module that export `add` function.
+After that, we use `wit-bindgen` to generate host code to execute the module.
+
+- `example.wit`: define the `add` function and the payload record with two `u32`s.
+- `lib`: a wasm module that export an `add` function generated from `example.wit`.
+- `host`: import the wasm module compiled from `lib` and then execute it with the payload.
+
+## Usage
+
+```
+git clone https://github.com/second-state/module-interaction-example.git
+cd module-interaction-example/integer-add
+cargo run --release
+```

--- a/wit-integer-add/host/Cargo.toml
+++ b/wit-integer-add/host/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "host"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", tag = "v0.2.0" }
+wasmtime = "0.39.1"
+wasmtime-wasi = "0.39.1"
+wasi-common = "0.39.1"

--- a/wit-integer-add/host/src/main.rs
+++ b/wit-integer-add/host/src/main.rs
@@ -1,0 +1,36 @@
+use example::{Example, ExampleData};
+use wasi_common::WasiCtx;
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::sync::WasiCtxBuilder;
+use wit_bindgen_wasmtime::anyhow::Result;
+
+use crate::example::Payload;
+
+wit_bindgen_wasmtime::import!("../wit/example.wit");
+
+fn main() -> Result<()> {
+    // Prepare WASI environment.
+    let engine = Engine::default();
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker(&mut linker, |s: &mut WasiCtx| s)?;
+    let wasi = WasiCtxBuilder::new()
+        .inherit_stdio()
+        .inherit_args()?
+        .build();
+    let mut store = Store::new(&engine, wasi);
+
+    // Load module.
+    let module = Module::from_file(&engine, "target/wasm32-wasi/release/lib.wasm")?;
+
+    // Initiate Example object.
+    static mut DATA: ExampleData = ExampleData {};
+    let (example_object, _) =
+        Example::instantiate(&mut store, &module, &mut linker, |_| unsafe { &mut DATA })?;
+
+    // Call `add` with payload.
+    let payload = Payload { a: 1, b: 2 };
+    let result = example_object.add(store, payload)?;
+    println!("Payload: {:?}", payload);
+    println!("Result: {}", result);
+    Ok(())
+}

--- a/wit-integer-add/lib/Cargo.toml
+++ b/wit-integer-add/lib/Cargo.toml
@@ -1,0 +1,13 @@
+cargo-features = [ "per-package-target" ]
+
+[package]
+name = "lib"
+version = "0.1.0"
+edition = "2021"
+default-target = "wasm32-wasi"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", tag = "v0.2.0" }

--- a/wit-integer-add/lib/src/lib.rs
+++ b/wit-integer-add/lib/src/lib.rs
@@ -1,0 +1,10 @@
+use example::Payload;
+
+wit_bindgen_rust::export!("../wit/example.wit");
+
+struct Example {}
+impl example::Example for Example {
+    fn add(p: Payload) -> u32 {
+        p.a + p.b
+    }
+}

--- a/wit-integer-add/wit/example.wit
+++ b/wit-integer-add/wit/example.wit
@@ -1,0 +1,6 @@
+record payload {
+  a: u32,
+  b: u32,
+}
+
+add: func(p: payload) -> u32


### PR DESCRIPTION
## Description

In this example, we use `wit-bindgen` to generate a wasm module that export `add` function.
After that, we use `wit-bindgen` to generate host code to execute the module.

- `example.wit`: define the `add` function and the payload record with two `u32`s.
- `lib`: a wasm module that export an `add` function generated from `example.wit`.
- `host`: import the wasm module compiled from `lib` and then execute it with the payload.

## Usage

```
git clone https://github.com/second-state/module-interaction-example.git
cd module-interaction-example/wit-integer-add
cargo run --release
```
