### PR TITLE
Add `slight-wasmedge`

### DIFF
--- a/slight-wasmedge/Cargo.toml
+++ b/slight-wasmedge/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["spidey", "wasmedge"]
+

--- a/slight-wasmedge/README.md
+++ b/slight-wasmedge/README.md
@@ -1,0 +1,22 @@
+## Description
+
+This example is a POC to run `spidey` example from [spiderlightning] using [WasmEdge].
+It only mocks the required functions but does not really store the key-value pair.
+
+## Usage
+
+```
+$ cargo build --release
+$ cargo run --release wasmedge
+kv::open
+-> name: my_folder
+kv::set
+-> key: hello-spiderlightning
+-> value: Hello, SpiderLightning!
+kv::get
+-> key: hello-spiderlightning
+resource_drop_kv
+```
+
+[spiderlightning]: https://github.com/deislabs/spiderlightning
+[WasmEdge]: https://github.com/WasmEdge/WasmEdge

--- a/slight-wasmedge/spidey/Cargo.toml
+++ b/slight-wasmedge/spidey/Cargo.toml
@@ -1,0 +1,19 @@
+cargo-features = [ "per-package-target" ]
+
+[package]
+name = "spidey"
+version = "0.1.0"
+edition = "2021"
+default-target = "wasm32-wasi"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+# ^^^ Flexible concrete Error type built on std::error::Error
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", tag = "v0.2.0" }
+# ^^^ A language binding generator for WebAssembly interface types
+wit-error-rs = { git = "https://github.com/danbugs/wit-error-rs", rev = "05362f1a4a3a9dc6a1de39195e06d2d5d6491a5e" }
+# ^^^ Convenience error-related trait implementations for types generated from a wit-bindgen import
+slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", rev = "efbae2d696713cd6bc559155db9ab4b4277bab08" }
+# ^^^ Macro for creating http request handlers when using SpiderLightning's http interface

--- a/slight-wasmedge/spidey/slightfile.toml
+++ b/slight-wasmedge/spidey/slightfile.toml
@@ -1,0 +1,5 @@
+specversion = "0.1"
+secret_store = "configs.envvars"
+
+[[capability]]
+name = "kv.filesystem"

--- a/slight-wasmedge/spidey/src/main.rs
+++ b/slight-wasmedge/spidey/src/main.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+
+use kv::*;
+wit_bindgen_rust::import!("wit/kv_v0.1.0/kv.wit");
+wit_error_rs::impl_error!(kv::Error);
+
+fn main() -> Result<()> {
+    let my_kv = Kv::open("my_folder")?;
+    my_kv.set("hello-spiderlightning", b"Hello, SpiderLightning!")?;
+    println!(
+        "{}",
+        std::str::from_utf8(&my_kv.get("hello-spiderlightning")?)?,
+    );
+
+    Ok(())
+}

--- a/slight-wasmedge/spidey/wit/kv_v0.1.0/kv.wit
+++ b/slight-wasmedge/spidey/wit/kv_v0.1.0/kv.wit
@@ -1,0 +1,20 @@
+// A key-value store interface.
+use { error, payload } from types
+use { observable } from resources
+
+resource kv {
+	// open a key-value store
+	static open: func(name: string) -> expected<kv, error>
+
+	// get the payload for a given key.
+	get: func(key: string) -> expected<payload, error> 
+
+	// set the payload for a given key.
+	set: func(key: string, value: payload) -> expected<unit, error>
+
+	// delete the payload for a given key.
+	delete: func(key:string) -> expected<unit, error>
+
+	// watch for changes to a key.
+	watch: func(key: string) -> expected<observable, error>
+}

--- a/slight-wasmedge/spidey/wit/kv_v0.1.0/resources.wit
+++ b/slight-wasmedge/spidey/wit/kv_v0.1.0/resources.wit
@@ -1,0 +1,4 @@
+record observable {
+	rd: string,
+	key: string,
+}

--- a/slight-wasmedge/spidey/wit/kv_v0.1.0/types.wit
+++ b/slight-wasmedge/spidey/wit/kv_v0.1.0/types.wit
@@ -1,0 +1,20 @@
+variant error {
+	error-with-description(string),
+}
+type payload = list<u8>
+type map = list<tuple<string, string>>
+
+// Cloudevents spec: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
+// We assume the type of the data is a byte sequence. It is up to the data schema to determine
+// what type of the data payload the event contains. 
+record event {
+	specversion: string,
+	ty: string,
+	source: string,
+	id: string,
+	data: option<payload>,
+	datacontenttype: option<string>,
+	dataschema: option<string>,
+	subject: option<string>,
+	time: option<string>,
+} 

--- a/slight-wasmedge/wasmedge/Cargo.toml
+++ b/slight-wasmedge/wasmedge/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wasmedge"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "*"
+wasmedge-sdk = "0.6.0"

--- a/slight-wasmedge/wasmedge/src/main.rs
+++ b/slight-wasmedge/wasmedge/src/main.rs
@@ -1,0 +1,69 @@
+#![feature(never_type)]
+use anyhow::Error;
+use wasmedge_sdk::{
+    config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
+    error::HostFuncError,
+    host_function, Caller, ImportObjectBuilder, Vm, WasmValue,
+};
+
+fn load_string(caller: &Caller, addr: u32, size: u32) -> String {
+    let mem = caller.memory(0).unwrap();
+    let data = mem.read(addr, size).expect("fail to get string");
+    String::from_utf8_lossy(&data).to_string()
+}
+
+#[host_function]
+fn kv_open(caller: Caller, args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    println!("kv::open");
+    let param = load_string(&caller, args[0].to_i32() as u32, args[1].to_i32() as u32);
+    println!("-> name: {}", param);
+    Ok(vec![])
+}
+
+#[host_function]
+fn kv_set(caller: Caller, args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    println!("kv::set");
+    let key = load_string(&caller, args[1].to_i32() as u32, args[2].to_i32() as u32);
+    let value = load_string(&caller, args[3].to_i32() as u32, args[4].to_i32() as u32);
+    println!("-> key: {}", key);
+    println!("-> value: {}", value);
+    Ok(vec![])
+}
+
+#[host_function]
+fn kv_get(caller: Caller, args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    println!("kv::get");
+    let key = load_string(&caller, args[1].to_i32() as u32, args[2].to_i32() as u32);
+    println!("-> key: {}", key);
+    Ok(vec![])
+}
+
+#[host_function]
+fn resource_drop_kv(_: Caller, _: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    println!("resource_drop_kv");
+    Ok(vec![])
+}
+
+fn main() -> Result<(), Error> {
+    // Register module and create VM.
+    let config = ConfigBuilder::new(CommonConfigOptions::default())
+        .with_host_registration_config(HostRegistrationConfigOptions::default().wasi(true))
+        .build()?;
+    let kv_module = ImportObjectBuilder::new()
+        .with_func::<(i32, i32, i32), (), !>("kv::open", kv_open, None)?
+        .with_func::<(i32, i32, i32, i32, i32, i32), (), !>("kv::set", kv_set, None)?
+        .with_func::<(i32, i32, i32, i32), (), !>("kv::get", kv_get, None)?
+        .build("kv")?;
+    let canon_module = ImportObjectBuilder::new()
+        .with_func::<i32, (), !>("resource_drop_kv", resource_drop_kv, None)?
+        .build("canonical_abi")?;
+    let vm = Vm::new(Some(config))?
+        .register_import_module(kv_module)?
+        .register_import_module(canon_module)?
+        .register_module_from_file("spidey", "target/wasm32-wasi/release/spidey.wasm")?;
+
+    // Execute spidey.
+    vm.run_func(Some("spidey"), "_start", None)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This example is a POC to run `spidey` example from [spiderlightning] using [WasmEdge].
It only mocks the required functions but does not really store the key-value pair.

This example is for issue https://github.com/WasmEdge/WasmEdge/issues/1892.

[spiderlightning]: https://github.com/deislabs/spiderlightning
[WasmEdge]: https://github.com/WasmEdge/WasmEdge
